### PR TITLE
Fix capability not being added to Xcode

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -23,6 +23,11 @@
         <string>Default</string>
       </array>
     </config-file>
+    <config-file target="*.entitlements" parent="com.apple.developer.applesignin">
+      <array>
+        <string>Default</string>
+      </array>
+    </config-file>
 
     <header-file src="src/ios/SignInWithApple.h" />
     <source-file src="src/ios/SignInWithApple.m" />


### PR DESCRIPTION
This PR fixes the issue with the Sign in with Apple capability not being automatically added to Xcode.

Fixes #5 