### PR TITLE
Fix operation and scope code parsing

### DIFF
--- a/src/ios/SIWAConverters.m
+++ b/src/ios/SIWAConverters.m
@@ -26,7 +26,7 @@ id SIWANullIfNil(id value)
 
 + (ASAuthorizationScope)convertScope: (NSNumber *)scope
 {
-    switch (scope.integerValue) {
+    switch (scope.intValue) {
         case 0:
             return ASAuthorizationScopeFullName;
         case 1:
@@ -38,7 +38,7 @@ id SIWANullIfNil(id value)
 
 + (ASAuthorizationOpenIDOperation)convertOperation: (NSNumber *)operation
 {
-    switch (operation.integerValue) {
+    switch (operation.intValue) {
         case 0:
             return ASAuthorizationOperationImplicit;
         case 1:


### PR DESCRIPTION
This fixes a bug where the plugin uses the values of the given operation and scope codes as `NSInteger` objects, but the switch statement uses `Int` values.